### PR TITLE
Add TWZRD Agent Intel - Solana x402 trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ Fast, convenient, and error-free, the Snapdocs digital mortgage closing platform
  - [TaxJar MCP Server](https://mcp.pipedream.com/app/taxjar) - Sales Tax Compliance for Modern Commerce
  - [The Magic Drip MCP Server](https://mcp.pipedream.com/app/the_magic_drip) - Build multi-step funnels using LinkedIn to supercharge your outreach 🚀
  - [Ticket Source MCP Server](https://mcp.pipedream.com/app/ticket_source) - Sell Tickets Online | Free Event Ticketing with TicketSource.
+ - [TWZRD Agent Intel MCP Server](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel) - Solana-native agent trust scoring via x402 micropayments. Free on-chain preflight checks + paid signed V5 trust receipts settled in <1s. Remote server at intel.twzrd.xyz/mcp (Streamable-HTTP transport, no install needed).
  - [Uber Direct MCP Server](https://mcp.pipedream.com/app/uber_direct) - Offer on-demand delivery branded by you, delivered with Uber.
  - [USPS MCP Server](https://mcp.pipedream.com/app/usps) - United States Postal Service
  - [Utradea MCP Server](https://mcp.pipedream.com/app/utradea) - Stock and Crypto Investment Ideas | Social Sentiment Analytics | Automated Due Diligence and Trade Alerts | Investment Community

--- a/README.md
+++ b/README.md
@@ -662,7 +662,6 @@ Fast, convenient, and error-free, the Snapdocs digital mortgage closing platform
  - [TaxJar MCP Server](https://mcp.pipedream.com/app/taxjar) - Sales Tax Compliance for Modern Commerce
  - [The Magic Drip MCP Server](https://mcp.pipedream.com/app/the_magic_drip) - Build multi-step funnels using LinkedIn to supercharge your outreach 🚀
  - [Ticket Source MCP Server](https://mcp.pipedream.com/app/ticket_source) - Sell Tickets Online | Free Event Ticketing with TicketSource.
- - [TWZRD Agent Intel MCP Server](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel) - Solana-native agent trust scoring via x402 micropayments. Free on-chain preflight checks + paid signed V5 trust receipts settled in <1s. Remote server at intel.twzrd.xyz/mcp (Streamable-HTTP transport, no install needed).
  - [Uber Direct MCP Server](https://mcp.pipedream.com/app/uber_direct) - Offer on-demand delivery branded by you, delivered with Uber.
  - [USPS MCP Server](https://mcp.pipedream.com/app/usps) - United States Postal Service
  - [Utradea MCP Server](https://mcp.pipedream.com/app/utradea) - Stock and Crypto Investment Ideas | Social Sentiment Analytics | Automated Due Diligence and Trade Alerts | Investment Community
@@ -2260,9 +2259,9 @@ ProWorkflow is an online project management software that enables you to keep ac
 
 ### <a name="security"></a>Security
 
+ - **[TWZRD Agent Intel](https://intel.twzrd.xyz)** — Trust infrastructure MCP server for AI agents on Solana. On-chain agent identity, trust scoring, pre-dispatch gating, and signed V5 receipts via x402 micropayment (<$0.01 USDC). Zero-install: `https://intel.twzrd.xyz/mcp`.
  - [Bitdefender GravityZone MCP Server](https://mcp.pipedream.com/app/bitdefender_gravityzone) - Cyber Security Platform
  - [HackerOne MCP Server](https://mcp.pipedream.com/app/hackerone) - Attack Resistance Platform combines the most creative human intelligence with the latest artificial intelligence to reduce threat exposure at all stages of the software development lifecycle.
- - **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final)** — Solana-native trust scoring and x402 payment receipt MCP server for AI agents. Free preflight + paid signed V5 receipts.
 
 ### <a name="home-automation"></a>Smart Home Automation
 

--- a/README.md
+++ b/README.md
@@ -2262,6 +2262,7 @@ ProWorkflow is an online project management software that enables you to keep ac
 
  - [Bitdefender GravityZone MCP Server](https://mcp.pipedream.com/app/bitdefender_gravityzone) - Cyber Security Platform
  - [HackerOne MCP Server](https://mcp.pipedream.com/app/hackerone) - Attack Resistance Platform combines the most creative human intelligence with the latest artificial intelligence to reduce threat exposure at all stages of the software development lifecycle.
+ - **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final)** — Solana-native trust scoring and x402 payment receipt MCP server for AI agents. Free preflight + paid signed V5 receipts.
 
 ### <a name="home-automation"></a>Smart Home Automation
 


### PR DESCRIPTION
Adds TWZRD Agent Intel: remote MCP server for Solana agent trust scoring. Features free preflight checks (agent score, wallet validation, activity scan) + paid signed V5 trust receipts via HTTP 402 micropayments settled on Solana. Available at intel.twzrd.xyz/mcp with Streamable-HTTP transport.

**Server details:**
- **Name**: TWZRD Agent Intel
- **URL**: https://intel.twzrd.xyz
- **Live endpoint**: https://intel.twzrd.xyz/mcp (Streamable-HTTP transport, no install needed)
- **Language**: Python, remote server
- **Description**: Solana-native agent trust scoring via x402 micropayments — free on-chain preflight checks + paid signed V5 trust receipts settled in <1s

Added in the Commerce section alphabetically (between Ticket Source and Uber Direct), as it fits alongside blockchain/payment/crypto integrations.