### PR TITLE
Add BuyWhere MCP Server to Commerce section

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ Designed to help every family, Beanstalk makes saving and investing easy no matt
  - [bexio MCP Server](https://mcp.pipedream.com/app/bexio) - Business software for small businesses, startups and self-employed individuals
  - [Big Cartel MCP Server](https://mcp.pipedream.com/app/big_cartel) - Easy Online Stores for Artists and Makers
  - [BigBox MCP Server](https://mcp.pipedream.com/app/bigbox) - BigBox is the real-time Home Depot Product Data API you've been looking for. No manual rules or web-scraper maintenance required.
+ - [BuyWhere MCP Server](https://github.com/BuyWhere/buywhere-mcp) - Cross-border product catalog for AI agents. Search and compare products from Singapore, SEA, and US markets. Install via `npx -y @buywhere/mcp-server`.
  - [BigCommerce MCP Server](https://mcp.pipedream.com/app/bigcommerce) - Ecommerce for a New Era
  - [BILL MCP Server](https://mcp.pipedream.com/app/bill) - The intelligent way to create and pay bills, send invoices, and get paid. Get started with BILL.
  - [Billsby MCP Server](https://mcp.pipedream.com/app/billsby) - The most powerful, customizable and easy to integrate subscription billing software used by hundreds of companies worldwide to simplify revenue operations


### PR DESCRIPTION
Adding BuyWhere MCP Server to the Commerce section.

Canonical copy:
- 300M+ products, 150,000+ stores
- Remote: https://api.buywhere.ai/mcp (Streamable HTTP)
- Install: `npx -y @buywhere/mcp-server`
- Registry: `io.github.BuyWhere/buywhere-mcp`
- GitHub: https://github.com/BuyWhere/buywhere-mcp
- Docs: https://buywhere.ai/docs/guides/mcp-integration
- Tools: 13
- Auth: API key

README line updated to match. Please ignore earlier comments on this PR that used stale 11M+/147M+/164M figures or the wrong package name.